### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>edu.drexel</groupId>
-  <artifactId>Bunch</artifactId>
+  <artifactId>bunch</artifactId>
   <packaging>jar</packaging>
 
   <name>Bunch4</name>


### PR DESCRIPTION
I ran into an issue where Bunch could not be used as an automatic module when using the Java Platform Module System in combination with Maven. Problem was that the artifactId is `Bunch` and the derived automatic module name `bunch`. Making the artifactId all lowercase fixed the issue for me and might help others.

The best fix would be to define an automatic module name like this
```xml
<configuration>
    <archive>
        <manifest>
            <mainClass>bunch.Bunch</mainClass>
        </manifest>
        <manifest-entries>
            <Automatic-Module-Name>edu.drexel.bunch</Automatic-Module-Name>
        </manifest-entries>
    </archive>
</configuration>
```
https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers
https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html